### PR TITLE
Fix broken user table migration

### DIFF
--- a/lib/generators/rails_mvp_authentication/install_generator.rb
+++ b/lib/generators/rails_mvp_authentication/install_generator.rb
@@ -175,7 +175,7 @@ module RailsMvpAuthentication
       end
 
       def create_users_table
-        generate "migration", "create_users_table email:string:index confirmed_at:datetime password_digest:string unconfirmed_email:string"
+        generate "migration", "create_users email:string:index confirmed_at:datetime password_digest:string unconfirmed_email:string"
       end
 
       def create_user_views
@@ -232,7 +232,7 @@ module RailsMvpAuthentication
         migration = Dir.glob(Rails.root.join("db/migrate/*")).max_by { |f| File.mtime(f) }
         gsub_file migration, /t.string :email/, "t.string :email, null: false"
         gsub_file migration, /t.string :password_digest/, "t.string :password_digest, null: false"
-        gsub_file migration, /add_index :users_tables, :email/, "add_index :users_tables, :email, unique: true"
+        gsub_file migration, /add_index :users, :email/, "add_index :users, :email, unique: true"
       end
 
       def path_to(path)

--- a/test/lib/generators/rails_mvp_authentication/install_generator_test.rb
+++ b/test/lib/generators/rails_mvp_authentication/install_generator_test.rb
@@ -11,8 +11,9 @@ class RailsMvpAuthentication::InstallGeneratorTest < Rails::Generators::TestCase
   test "creates migration for users table" do
     run_generator
 
-    assert_migration "db/migrate/create_users_table.rb" do |migration|
-      assert_match(/add_index :users_tables, :email, unique: true/, migration)
+    assert_migration "db/migrate/create_users.rb" do |migration|
+      assert_match(/create_table :users do |t|/, migration)
+      assert_match(/add_index :users, :email, unique: true/, migration)
       assert_match(/t.string :email, null: false/, migration)
       assert_match(/t.string :password_digest, null: false/, migration)
     end


### PR DESCRIPTION
The orignal command was creating a "users_tables" table instead of a "users" table.

Issues
------
- Closes #29