### PR TITLE
Render form errors inline

### DIFF
--- a/lib/generators/rails_mvp_authentication/templates/views/users/edit.html.erb.tt
+++ b/lib/generators/rails_mvp_authentication/templates/views/users/edit.html.erb.tt
@@ -1,5 +1,11 @@
 <%%= form_with model: @user, url: account_path, method: :put do |form| %>
-  <%%= render partial: "shared/form_errors", locals: { object: form.object } %>
+  <%% if form.object.errors.any? %>
+    <ul>
+      <%% form.object.errors.full_messages.each do |message| %>
+        <li><%%= message %></li>
+      <%% end %>
+    </ul>
+  <%% end %>
   <div>
     <%%= form.label :email, "Current Email" %>
     <%%= form.email_field :email, disabled: true %>

--- a/lib/generators/rails_mvp_authentication/templates/views/users/new.html.erb.tt
+++ b/lib/generators/rails_mvp_authentication/templates/views/users/new.html.erb.tt
@@ -1,5 +1,11 @@
 <%%= form_with model: @user, url: sign_up_path do |form| %>
-  <%%= render partial: "shared/form_errors", locals: { object: form.object } %>
+  <%% if form.object.errors.any? %>
+    <ul>
+      <%% form.object.errors.full_messages.each do |message| %>
+        <li><%%= message %></li>
+      <%% end %>
+    </ul>
+  <%% end %>
   <div>
     <%%= form.label :email %>
     <%%= form.email_field :email, required: true %>


### PR DESCRIPTION
The original guide uses a partial to render form errors, but it's easier to add this inline in our templates.

Issues
------
- Closes #33