### PR TITLE
Drop sprockets-rails dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     rails_mvp_authentication (0.1.0)
       rails (>= 7.0.0)
-      sprockets-rails (~> 3.4, >= 3.4.2)
 
 GEM
   remote: https://rubygems.org/

--- a/rails_mvp_authentication.gemspec
+++ b/rails_mvp_authentication.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.0.0"
-  spec.add_dependency "sprockets-rails", "~> 3.4", ">= 3.4.2"
 end


### PR DESCRIPTION
This was incorrectly set as a gem dependency when we only really needed it for development.

Issues
------
- Closes #35